### PR TITLE
Auto update analysis report with timestamp.

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1,15 +1,64 @@
 import json
+import os
+import re
+from datetime import datetime
+import subprocess
+
+
+def parse_template_keys(template_path):
+    """Extract placeholder keys from the template."""
+    with open(template_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    return set(re.findall(r"{(.*?)}", content))
 
 def generate_report_from_template(template_path, output_path, variables):
+    keys = parse_template_keys(template_path)
+    missing = []
     with open(template_path, "r", encoding="utf-8") as f:
         template = f.read()
-    for key, val in variables.items():
-        template = template.replace(f"{{{{{key}}}}}", str(val))
+
+    # add default variables
+    variables.setdefault(
+        "generation_date", datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
+    try:
+        commit_hash = (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+            .decode()
+            .strip()
+        )
+    except Exception:
+        commit_hash = "unknown"
+    variables.setdefault("commit_hash", commit_hash)
+
+    for key in keys:
+        if key not in variables:
+            missing.append(key)
+            value = "N/A"
+        else:
+            value = variables[key]
+        template = template.replace(f"{{{key}}}", str(value))
+
+    if missing:
+        print("Missing keys in results.json:", ", ".join(missing))
+
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(template)
     print(f"Report generated: {output_path}")
 
+def load_variables(json_path):
+    if os.path.exists(json_path):
+        with open(json_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    print(f"Results file not found: {json_path}")
+    return {}
+
+
 if __name__ == "__main__":
-    with open("./output/results.json", "r") as f:
-        variables = json.load(f)
-    generate_report_from_template("template.md", "generated_report.md", variables)
+    vars_path = os.path.join("output", "results.json")
+    variables = load_variables(vars_path)
+    generate_report_from_template(
+        "template.md",
+        "generated_report.md",
+        variables,
+    )


### PR DESCRIPTION
## Summary
- add template placeholder extraction for report variables
- check missing keys from results.json
- fill defaults (generation date and commit hash) when generating Markdown reports

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement affine)*
- `python run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6849219203cc83299ea22ea32cdede3e