### PR TITLE
Add NDVI download script

### DIFF
--- a/scripts/download_ndvi_amazon.py
+++ b/scripts/download_ndvi_amazon.py
@@ -1,0 +1,36 @@
+import os
+import ee
+import geemap
+
+"""Download yearly median NDVI for the Amazon basin.
+
+This script requires Google Earth Engine authentication. Run `earthengine authenticate`
+before executing. NDVI images for each year from 2015 through 2024 are exported
+as GeoTIFFs in the current directory.
+"""
+
+def main():
+    # Initialize Earth Engine
+    ee.Initialize()
+
+    # Approximate Amazon basin bounding box
+    amazon_basin = ee.Geometry.BBox(-74.0, -20.0, -50.0, 5.0)
+
+    collection = ee.ImageCollection('MODIS/006/MOD13A2').select('NDVI')
+
+    for year in range(2015, 2025):
+        start = f"{year}-01-01"
+        end = f"{year}-12-31"
+        image = collection.filterDate(start, end).median()
+        filename = f"amazon_ndvi_{year}.tif"
+        print(f"Exporting {filename} ...")
+        geemap.ee_export_image(
+            image,
+            filename=filename,
+            region=amazon_basin,
+            scale=1000,
+            file_per_band=False,
+        )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to export yearly NDVI GeoTIFFs for the Amazon basin

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_684bbd0aa1348329ac4eb986b337344e