### PR TITLE
Fix BOM in requirements-fixed

### DIFF
--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -1,4 +1,4 @@
-﻿affine==2.4.0
+affine==2.4.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.8
 aiosignal==1.3.2
@@ -164,7 +164,7 @@ xmod==1.8.1
 yarl==1.20.0
 yaspin==3.1.0
 zipp==3.22.0
-﻿affine==2.4.0
+affine==2.4.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.8
 aiosignal==1.3.2


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM characters from `requirements-fixed.txt`

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857b4b867c08329a3eb7213bc042cce