### PR TITLE
Add NDVI export script and tests

### DIFF
--- a/scripts/gee_ndvi_export.py
+++ b/scripts/gee_ndvi_export.py
@@ -1,0 +1,26 @@
+import os
+from PIL import Image
+
+
+def export_ndvi_image(lat, lon, size=(256, 256), output_dir="output/images"):
+    """Mock export of an NDVI image for the given coordinates."""
+    os.makedirs(output_dir, exist_ok=True)
+    filename = f"ndvi_{lat}_{lon}.png"
+    path = os.path.join(output_dir, filename)
+    # Simple placeholder image
+    img = Image.new("RGB", size, (0, 128, 0))
+    img.save(path)
+    return path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Mock NDVI export")
+    parser.add_argument("lat", type=float)
+    parser.add_argument("lon", type=float)
+    parser.add_argument("--output", default="output/images")
+    args = parser.parse_args()
+    result = export_ndvi_image(args.lat, args.lon, output_dir=args.output)
+    print(result)
+

--- a/tests/test_gee_ndvi_export.py
+++ b/tests/test_gee_ndvi_export.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+import tempfile
+
+from scripts import gee_ndvi_export
+
+
+class TestGeeNdviExport(unittest.TestCase):
+    def test_export_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = gee_ndvi_export.export_ndvi_image(0.5, -60.5, output_dir=tmpdir)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(path.endswith('.png'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_results_template.py
+++ b/tests/test_results_template.py
@@ -1,0 +1,24 @@
+import os
+import json
+import unittest
+
+from scripts import report_generator
+
+
+class TestResultsAndTemplate(unittest.TestCase):
+    def test_results_json_and_template_render(self):
+        path = os.path.join('output', 'results.json')
+        self.assertTrue(os.path.exists(path), 'results.json missing')
+        with open(path, 'r') as f:
+            data = json.load(f)
+
+        for key in ['max_ndvi', 'candidate_count', 'image_path']:
+            self.assertIn(key, data)
+
+        markdown = report_generator.render_markdown(report_generator.TEMPLATE_PATH, data)
+        self.assertIsInstance(markdown, str)
+        self.assertGreater(len(markdown), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- mock NDVI export script in `scripts/`
- validate NDVI export, results JSON and template rendering via unittest
- ensure default unittest discovery works

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857b4bd20ac8329bdd49597e11b6f51