### PR TITLE
Update NDVI export test

### DIFF
--- a/tests/test_gee_ndvi_export.py
+++ b/tests/test_gee_ndvi_export.py
@@ -3,12 +3,74 @@ import unittest
 import tempfile
 
 from scripts import gee_ndvi_export
+from types import SimpleNamespace
+
+
+class FakeGeometry:
+    @staticmethod
+    def Point(lon, lat):
+        class _Geom:
+            def buffer(self, radius):
+                return self
+
+            def bounds(self):
+                return self
+
+        return _Geom()
+
+
+class FakeImage:
+    def normalizedDifference(self, bands):
+        return self
+
+    def rename(self, name):
+        return self
+
+
+class FakeCollection:
+    def __init__(self, name=None):
+        pass
+
+    def filterBounds(self, bbox):
+        return self
+
+    def filterDate(self, start, end):
+        return self
+
+    def filter(self, *_):
+        return self
+
+    def median(self):
+        return FakeImage()
+
+
+class FakeFilter:
+    @staticmethod
+    def lt(a, b):
+        return None
+
+
+class FakeEE(SimpleNamespace):
+    Geometry = FakeGeometry
+    ImageCollection = FakeCollection
+    Filter = FakeFilter
 
 
 class TestGeeNdviExport(unittest.TestCase):
     def test_export_creates_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            path = gee_ndvi_export.export_ndvi_image(0.5, -60.5, output_dir=tmpdir)
+            # Patch the ee and geemap modules to avoid Earth Engine calls
+            gee_ndvi_export.ee = FakeEE()
+
+            def fake_export_image(*args, filename=None, **kwargs):
+                with open(filename, "w") as f:
+                    f.write("")
+
+            gee_ndvi_export.geemap.ee_export_image = fake_export_image
+
+            path = gee_ndvi_export.export_site_ndvi(
+                "test_site", 0.5, -60.5, tmpdir
+            )
             self.assertTrue(os.path.exists(path))
             self.assertTrue(path.endswith('.png'))
 


### PR DESCRIPTION
## Summary
- adjust gee export test to use `export_site_ndvi`
- mock Earth Engine & geemap APIs so unit tests run without network

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857b97c86648329973c87103667a5e4