### PR TITLE
Improve GEE authentication handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ pip install -r requirements.txt
 python run_pipeline.py --site O3
 ```
 
+### Earth Engine Authentication
+
+Before using scripts that access Google Earth Engine, authenticate with your
+user account:
+
+```bash
+earthengine authenticate
+```
+
+Alternatively, set the path to a service account JSON key via the
+`EE_SERVICE_ACCOUNT_FILE` environment variable:
+
+```bash
+export EE_SERVICE_ACCOUNT_FILE=/path/to/your-service-account.json
+```
+
 ---
 
 ## 📊 AI-Predicted Ruin-likeness Score

--- a/tests/test_gee_ndvi_export.py
+++ b/tests/test_gee_ndvi_export.py
@@ -1,17 +1,44 @@
 import os
-import unittest
 import tempfile
+import unittest
+from unittest import mock
 
 from scripts import gee_ndvi_export
 
 
 class TestGeeNdviExport(unittest.TestCase):
-    def test_export_creates_file(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = gee_ndvi_export.export_ndvi_image(0.5, -60.5, output_dir=tmpdir)
-            self.assertTrue(os.path.exists(path))
-            self.assertTrue(path.endswith('.png'))
+    @mock.patch("geemap.ee_export_image")
+    def test_export_creates_file(self, mock_export):
+        def fake_export(image, filename, **kwargs):
+            with open(filename, "w") as f:
+                f.write("test")
+        mock_export.side_effect = fake_export
+
+        fake_ee = mock.MagicMock()
+        point = mock.MagicMock()
+        point.buffer.return_value.bounds.return_value = "bbox"
+        fake_ee.Geometry.Point.return_value = point
+        collection = mock.MagicMock()
+        collection.filterBounds.return_value = collection
+        collection.filterDate.return_value = collection
+        collection.filter.return_value = collection
+        median = mock.MagicMock()
+        collection.median.return_value = median
+        median.normalizedDifference.return_value.rename.return_value = "img"
+        fake_ee.ImageCollection.return_value = collection
+        fake_ee.Filter.lt.return_value = None
+
+        with mock.patch.object(gee_ndvi_export, "ee", fake_ee):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = gee_ndvi_export.export_site_ndvi("Site", 0.5, -60.5, tmpdir)
+                self.assertTrue(os.path.exists(path))
+                self.assertTrue(path.endswith("_ndvi_2023.png"))
+
+    @mock.patch("scripts.gee_ndvi_export.ee.Initialize", side_effect=Exception("Auth fail"))
+    def test_initialize_failure_exits(self, mock_init):
+        with self.assertRaises(SystemExit):
+            gee_ndvi_export.initialize_earthengine()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- exit gracefully if Earth Engine authentication fails
- explain how to authenticate Earth Engine or use a service account
- update tests for new initialization logic

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857b976f3fc8329bf86ad967f89b886