### PR TITLE
Add Earth Engine tool dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Dependencies:
 - matplotlib, pandas, numpy
 ```
 
+### 📦 Installation
+
+Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+
 ---
 
 ## 🥷 Place Name Ninjutsu

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pillow==11.2.1
+geemap
+earthengine-api>=0.1.375
+pandas==2.3.0


### PR DESCRIPTION
## Summary
- list dependencies in README and add install instructions
- add geemap, earthengine-api, Pillow, and pandas to requirements.txt

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover` *(fails: Module 'scripts.gee_ndvi_export' has no attribute 'export_ndvi_image')*

------
https://chatgpt.com/codex/tasks/task_e_6857b980acc48329a62318fa024e0524