### PR TITLE
Remove duplicate pipeline workflow

### DIFF
--- a/workflows/auto-pipeline.yml
+++ b/workflows/auto-pipeline.yml
@@ -1,7 +1,0 @@
-      - name: Commit & Push results
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "Auto update analysis report (`date`)" || echo "Nothing to commit"
-          git push


### PR DESCRIPTION
## Summary
- remove redundant `workflows/auto-pipeline.yml` so only `.github/workflows/auto_report.yml` handles report commits

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6857fa8445248329b666d080c7c35987