### PR TITLE
Add trigger conditions for auto_report workflow

### DIFF
--- a/.github/workflows/auto_report.yml
+++ b/.github/workflows/auto_report.yml
@@ -1,3 +1,9 @@
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- trigger `auto_report` workflow on pushes to `main`
- allow manual runs with `workflow_dispatch`

## Testing
- `pip install -r requirements.txt`
- `python run_pipeline.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6857fa81fdf08329993ddf2deba5fd5a